### PR TITLE
build: Fix build errors on local and CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
-      - run: gradle build publishToMavenLocal
+      - run: ./gradlew build publishToMavenLocal
       - store_test_results:
           path: core/build/test-results
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     }
     dependencies {
         classpath "org.junit.platform:junit-platform-gradle-plugin:${rootProject.ext.junitGradlePluginVersion}"
-        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.+'
+        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.8.1'
     }
 }
 


### PR DESCRIPTION
# What's changed

## Use version 4.8.1 of com.jfrog.artifactory Gradle plugin

Because build error occurs if version 4.9.0 (or newer) is used.

```
 * Where:
 Build file 'C:\Users\nobuoka\Documents\projects\vc-oauth-java\build.gradle' line: 65
 
 * What went wrong:
 A problem occurred evaluating root project 'vc-oauth-java'.
 > Failed to apply plugin [id 'com.jfrog.artifactory']
    > No signature of method: org.gradle.api.internal.tasks.RealizableTaskCollection.configureEach() is applicable for argument types: (org.jfrog.gradle.plugin.artifactory.ArtifactoryPluginBase$_addModuleInfoTask_closure1) values: [org.jfrog.gradle.plugin.artifactory.ArtifactoryPluginBase$_addModuleInfoTask_closure1@28746fb7]
```

## Use Gradle wrapper on CircleCI

Because build error occurs if version 6.4.1 is used.

```
* Where:
Build file '/home/circleci/project/build.gradle' line: 30

* What went wrong:
An exception occurred applying plugin request [id: 'com.gradle.build-scan', version: '1.11']
> Failed to apply plugin [id 'com.gradle.build-scan']
   > The build scan plugin is not compatible with this version of Gradle.
     Please see https://gradle.com/help/gradle-6-build-scan-plugin for more information.
```