### PR TITLE
build: Modify version notation of dependencies

### DIFF
--- a/googleHttpClientCooperator/build.gradle
+++ b/googleHttpClientCooperator/build.gradle
@@ -19,7 +19,7 @@ tasks.withType(Javadoc) {
 dependencies {
     compile project(':core')
 
-    compile 'com.google.http-client:google-http-client:1.19'
+    compile 'com.google.http-client:google-http-client:1.19.0'
     compile 'info.vividcode.utils:wscutils:0.2.0'
 }
 

--- a/googleHttpClientCooperator/build.gradle
+++ b/googleHttpClientCooperator/build.gradle
@@ -19,8 +19,8 @@ tasks.withType(Javadoc) {
 dependencies {
     compile project(':core')
 
-    compile 'com.google.http-client:google-http-client:1.19+'
-    compile 'info.vividcode.utils:wscutils:0.2.0+'
+    compile 'com.google.http-client:google-http-client:1.19'
+    compile 'info.vividcode.utils:wscutils:0.2.0'
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {


### PR DESCRIPTION
```
Because current notation is Maven incompatible.

Before it's changed, Gradle shows following message:
> Maven publication 'maven' contains dependencies that will produce a pom file
> that cannot be consumed by a Maven client.
>   - com.google.http-client:google-http-client:1.19+ declared with a Maven
>     incompatible version notation
>   - info.vividcode.utils:wscutils:0.2.0+ declared with a Maven incompatible
>     version notation
```